### PR TITLE
Add unit declarator to module and role declarations

### DIFF
--- a/lib/Inline.pm
+++ b/lib/Inline.pm
@@ -1,5 +1,5 @@
 
-module Inline;
+unit module Inline;
 
 use Inline::C;
 

--- a/lib/Inline/C.pm
+++ b/lib/Inline/C.pm
@@ -1,5 +1,5 @@
 
-role Inline::C[Routine $r, Str $language, Str $code];
+unit role Inline::C[Routine $r, Str $language, Str $code];
 
 use NativeCall;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.